### PR TITLE
Match multi-type entities with document matcher

### DIFF
--- a/lib/grape_entity_matchers/document_matcher.rb
+++ b/lib/grape_entity_matchers/document_matcher.rb
@@ -24,6 +24,11 @@ module GrapeEntityMatchers
         self
       end
 
+      def types(types_value)
+        @types = types_value
+        self
+      end
+
       def required(required_value)
         @required = required_value
         self
@@ -66,6 +71,7 @@ module GrapeEntityMatchers
         @documentation ||
             {
               type: @type,
+              types: @types,
               desc: @desc,
               required: @required,
               default: @default,

--- a/spec/grape_entity_matchers/document_matcher_spec.rb
+++ b/spec/grape_entity_matchers/document_matcher_spec.rb
@@ -5,6 +5,7 @@ describe GrapeEntityMatchers::DocumentMatcher do
   let(:documentation) do
     {
       type: String,
+      types: [String, Integer],
       desc: 'Some string',
       default: 'xyz',
       required: false,
@@ -15,6 +16,7 @@ describe GrapeEntityMatchers::DocumentMatcher do
     class TestEntity < Grape::Entity
       expose :str, documentation: {
         type: String,
+        types: [String, Integer],
         desc: 'Some string',
         default: 'xyz',
         required: false,
@@ -33,6 +35,9 @@ describe GrapeEntityMatchers::DocumentMatcher do
   context "ensure individual keys of documentation" do
     it { is_expected.to document(:str).type(String) }
     it { is_expected.not_to document(:str).type(Fixnum) }
+
+    it { is_expected.to document(:str).types([String, Integer])}
+    it { is_expected.not_to document(:str).types([String, Integer, Fixnum]) }
 
     it { is_expected.to document(:str).desc('Some string') }
     it { is_expected.not_to document(:str).desc('Some other string') }


### PR DESCRIPTION
This PR introduces adds the `types` key to the document matcher to support testing multi-type entities.

@timothysu 